### PR TITLE
Add employee dashboard with sidebar, header, and summary cards

### DIFF
--- a/frontend/app/employee/layout.tsx
+++ b/frontend/app/employee/layout.tsx
@@ -1,0 +1,16 @@
+import Sidebar from "@/components/layout/Sidebar";
+
+export default function EmployeeLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex min-h-screen bg-sky-50/50">
+      <Sidebar role="employee" />
+      <main className="flex-1 p-6 md:p-10">
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/frontend/app/employee/page.tsx
+++ b/frontend/app/employee/page.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import Header from "@/components/layout/Header";
+import SummaryCard from "@/components/cards/SummaryCard";
+import StatusBadge from "@/components/ui/StatusBadge";
+
+// TODO: Replace with real API data
+const mockUser = {
+  name: "Sara",
+};
+
+const mockBalances = {
+  vacation: { used: 5, total: 20 },
+  personal: { used: 6, total: 10 },
+};
+
+const mockRequests = [
+  {
+    requestId: 1,
+    leaveType: "Vacation",
+    startDate: "2026-05-20",
+    endDate: "2026-05-24",
+    status: "Pending" as const,
+  },
+  {
+    requestId: 2,
+    leaveType: "Personal",
+    startDate: "2026-04-30",
+    endDate: "2026-04-30",
+    status: "Approved" as const,
+  },
+  {
+    requestId: 3,
+    leaveType: "Vacation",
+    startDate: "2026-04-15",
+    endDate: "2026-04-15",
+    status: "Rejected" as const,
+    managerComment: "Too many people out that week.",
+  },
+];
+
+const mockHistory = {
+  lastVacation: {
+    startDate: "2026-03-12",
+    endDate: "2026-03-18",
+    days: 5,
+  },
+  lastPersonal: {
+    startDate: "2026-01-09",
+    endDate: "2026-01-09",
+    days: 1,
+  },
+  totalUsedThisYear: 10,
+};
+
+function formatDate(dateStr: string) {
+  const d = new Date(dateStr + "T00:00:00");
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function calculateDays(start: string, end: string) {
+  const s = new Date(start + "T00:00:00");
+  const e = new Date(end + "T00:00:00");
+  return Math.ceil((e.getTime() - s.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+}
+
+export default function EmployeeDashboard() {
+  const pendingCount = mockRequests.filter((r) => r.status === "Pending").length;
+  const vacationPercent = Math.round(
+    ((mockBalances.vacation.total - mockBalances.vacation.used) / mockBalances.vacation.total) * 100
+  );
+  const personalPercent = Math.round(
+    ((mockBalances.personal.total - mockBalances.personal.used) / mockBalances.personal.total) * 100
+  );
+
+  return (
+    <div>
+      <Header userName={mockUser.name} showNewRequestButton />
+
+      {/* Summary Cards */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
+        <SummaryCard
+          label="Vacation balance"
+          value={`${vacationPercent}%`}
+          subtitle={`${mockBalances.vacation.total - mockBalances.vacation.used} days remaining out of ${mockBalances.vacation.total}`}
+          bgColor="bg-green-100"
+          progressBar={{
+            used: mockBalances.vacation.used,
+            total: mockBalances.vacation.total,
+            color: "bg-indigo-500",
+          }}
+        />
+        <SummaryCard
+          label="Personal balance"
+          value={`${personalPercent}%`}
+          subtitle={`${mockBalances.personal.total - mockBalances.personal.used} days remaining out of ${mockBalances.personal.total}`}
+          bgColor="bg-blue-100"
+          progressBar={{
+            used: mockBalances.personal.used,
+            total: mockBalances.personal.total,
+            color: "bg-emerald-500",
+          }}
+        />
+        <SummaryCard
+          label="Pending requests"
+          value={pendingCount}
+          subtitle={`${pendingCount} pending ${pendingCount === 1 ? "request" : "requests"}`}
+          valueColor="text-orange-500"
+          bgColor="bg-orange-50"
+        />
+      </div>
+
+      {/* My Recent Requests & History */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {/* My Recent Requests */}
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900 mb-4">
+            My Recent Requests
+          </h3>
+          <div className="space-y-3">
+            {mockRequests.map((request) => (
+              <div
+                key={request.requestId}
+                className="bg-white rounded-xl p-4 border border-gray-100 shadow-sm"
+              >
+                <div className="flex items-center justify-between mb-1">
+                  <p className="font-medium text-gray-900">
+                    {request.leaveType}
+                  </p>
+                  <StatusBadge status={request.status} />
+                </div>
+                <p className="text-sm text-gray-500">
+                  Requested for {formatDate(request.startDate)}
+                  {request.startDate !== request.endDate &&
+                    ` - ${formatDate(request.endDate)}`}
+                </p>
+                {request.managerComment && (
+                  <p className="text-sm text-red-500 mt-2">
+                    {request.managerComment}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* History */}
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900 mb-4">
+            History
+          </h3>
+          <div className="space-y-3">
+            <div className="bg-sky-50 rounded-xl p-4 border border-sky-100">
+              <p className="font-medium text-gray-900">Last Vacation Leave</p>
+              <p className="text-sm text-gray-500 mt-1">
+                {formatDate(mockHistory.lastVacation.startDate)} -{" "}
+                {formatDate(mockHistory.lastVacation.endDate)}
+              </p>
+              <p className="text-sm text-gray-500">
+                {mockHistory.lastVacation.days} days
+              </p>
+            </div>
+
+            <div className="bg-sky-50 rounded-xl p-4 border border-sky-100">
+              <p className="font-medium text-gray-900">Last Personal Leave</p>
+              <p className="text-sm text-gray-500 mt-1">
+                {formatDate(mockHistory.lastPersonal.startDate)}
+              </p>
+              <p className="text-sm text-gray-500">
+                {mockHistory.lastPersonal.days} day
+              </p>
+            </div>
+
+            <div className="bg-sky-50 rounded-xl p-4 border border-sky-100">
+              <p className="font-medium text-gray-900">Days Used This Year</p>
+              <p className="text-sm text-gray-500 mt-1">
+                Total: {mockHistory.totalUsedThisYear} days
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/employee/submit/page.tsx
+++ b/frontend/app/employee/submit/page.tsx
@@ -31,9 +31,15 @@ export default function LeaveRequestForm() {
 
   const handleSubmit = (e: React.SyntheticEvent) => {
     e.preventDefault();
+
+    const leaveTypeMap: Record<string, number> = {
+      vacation: 1,
+      personal: 2,
+    };
+
     console.log("Leave request submitted:", {
       description,
-      leaveType,
+      leaveTypeId: leaveTypeMap[leaveType],
       leaveMode,
       startDate,
       endDate,

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,9 +1,9 @@
-
+import { redirect } from "next/navigation";
 
 export default function Home() {
-  return (
-    <div className="h-screen flex items-center justify-center text-5xl">
-      <h1>This will be our app dashboard</h1>
-    </div>
-  );
+  // TODO: Check auth token and redirect based on role
+  // if (user.role === "manager") redirect("/manager");
+  // if (user.role === "employee") redirect("/employee");
+
+  redirect("/login");
 }

--- a/frontend/components/cards/SummaryCard.tsx
+++ b/frontend/components/cards/SummaryCard.tsx
@@ -1,0 +1,50 @@
+interface SummaryCardProps {
+  label: string;
+  value: string | number;
+  subtitle?: string;
+  valueColor?: string;
+  bgColor?: string;
+  progressBar?: {
+    used: number;
+    total: number;
+    color?: string;
+  };
+}
+
+export default function SummaryCard({
+  label,
+  value,
+  subtitle,
+  valueColor = "text-gray-900",
+  bgColor = "bg-green-100",
+  progressBar,
+}: SummaryCardProps) {
+  return (
+    <div className={`${bgColor} rounded-2xl p-5 min-w-[180px]`}>
+      <p className="text-sm font-medium text-gray-700">{label}</p>
+      <p className={`text-3xl font-bold mt-2 ${valueColor}`}>
+        {value}
+      </p>
+      {subtitle && (
+        <p className="text-xs text-gray-500 mt-1">{subtitle}</p>
+      )}
+      {progressBar && (
+        <div className="mt-3">
+          <div className="flex items-center gap-2">
+            <div className="flex-1 h-2 bg-white/60 rounded-full overflow-hidden">
+              <div
+                className={`h-full rounded-full transition-all ${progressBar.color || "bg-indigo-500"}`}
+                style={{
+                  width: `${(progressBar.used / progressBar.total) * 100}%`,
+                }}
+              />
+            </div>
+            <span className="text-xs font-semibold text-gray-600">
+              {progressBar.used}/{progressBar.total}
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/layout/Header.tsx
+++ b/frontend/components/layout/Header.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import Link from "next/link";
+
+interface HeaderProps {
+  userName: string;
+  showNewRequestButton?: boolean;
+}
+
+export default function Header({ userName, showNewRequestButton = false }: HeaderProps) {
+  const today = new Date().toLocaleDateString("en-US", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  return (
+    <div className="flex items-center justify-between mb-8">
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900">Hello, {userName}</h2>
+        <p className="text-sm text-gray-500">{today}</p>
+      </div>
+      {showNewRequestButton && (
+        <Link
+          href="/employee/submit"
+          className="px-5 py-2.5 border border-gray-300 rounded-full text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+        >
+          New Leave Request
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+interface SidebarProps {
+  role: "employee" | "manager";
+}
+
+const employeeLinks = [
+  { label: "Dashboard", href: "/employee", icon: "M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" },
+  { label: "Submit Request", href: "/employee/submit", icon: "M12 4v16m8-8H4" },
+  { label: "My Requests", href: "/employee/requests", icon: "M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" },
+  { label: "Settings", href: "/employee/settings", icon: "M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z M15 12a3 3 0 11-6 0 3 3 0 016 0z" },
+];
+
+const managerLinks = [
+  { label: "Dashboard", href: "/manager", icon: "M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" },
+  { label: "Pending Requests", href: "/manager/pending", icon: "M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" },
+  { label: "Team Calendar", href: "/manager/calendar", icon: "M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" },
+  { label: "All Requests", href: "/manager/requests", icon: "M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" },
+  { label: "Settings", href: "/manager/settings", icon: "M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z M15 12a3 3 0 11-6 0 3 3 0 016 0z" },
+];
+
+export default function Sidebar({ role }: SidebarProps) {
+  const pathname = usePathname();
+  const links = role === "manager" ? managerLinks : employeeLinks;
+
+  return (
+    <aside className="w-64 border-r border-gray-200 min-h-screen p-6 bg-white hidden md:block">
+      <div className="mb-8">
+        <h1 className="text-xl font-bold text-gray-900">LeaveHub</h1>
+      </div>
+
+      <div className="mb-8 text-center">
+        <div className="w-16 h-16 bg-gray-200 rounded-full mx-auto mb-2" />
+        <p className="font-medium text-gray-900">Sarah Connor</p>
+        <p className="text-sm text-gray-500">sarah@company.com</p>
+        <p className="text-xs text-gray-400 mt-1 capitalize">{role}</p>
+      </div>
+
+      <nav className="space-y-1">
+        {links.map((link) => {
+          const isActive = pathname === link.href;
+          return (
+            <Link
+              key={link.href}
+              href={link.href}
+              className={`flex items-center gap-3 px-4 py-2.5 text-sm rounded-lg transition-colors ${
+                isActive
+                  ? "bg-indigo-50 text-indigo-700 font-medium"
+                  : "text-gray-600 hover:bg-gray-50"
+              }`}
+            >
+              <svg
+                className="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.5}
+                  d={link.icon}
+                />
+              </svg>
+              {link.label}
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}

--- a/frontend/components/ui/LeaveTypeBadge.tsx
+++ b/frontend/components/ui/LeaveTypeBadge.tsx
@@ -1,0 +1,18 @@
+type LeaveType = "Vacation" | "Personal";
+
+interface LeaveTypeBadgeProps {
+  type: LeaveType;
+}
+
+const typeStyles: Record<LeaveType, string> = {
+  "Vacation": "bg-blue-100 text-blue-800",
+  "Personal": "bg-amber-100 text-amber-800",
+};
+
+export default function LeaveTypeBadge({ type }: LeaveTypeBadgeProps) {
+  return (
+    <span className={`text-xs font-medium px-2.5 py-1 rounded-md ${typeStyles[type]}`}>
+      {type}
+    </span>
+  );
+}

--- a/frontend/components/ui/StatusBadge.tsx
+++ b/frontend/components/ui/StatusBadge.tsx
@@ -1,0 +1,20 @@
+type Status = "Pending" | "Approved" | "Rejected" | "Revision Requested";
+
+interface StatusBadgeProps {
+  status: Status;
+}
+
+const statusStyles: Record<Status, string> = {
+  "Pending": "bg-yellow-100 text-yellow-800",
+  "Approved": "bg-green-100 text-green-800",
+  "Rejected": "bg-red-100 text-red-800",
+  "Revision Requested": "bg-purple-100 text-purple-800",
+};
+
+export default function StatusBadge({ status }: StatusBadgeProps) {
+  return (
+    <span className={`text-xs font-medium px-2.5 py-1 rounded-md ${statusStyles[status]}`}>
+      {status}
+    </span>
+  );
+}


### PR DESCRIPTION
Added the employee dashboard and shared layout components.

Pages:
- Updated app/page.tsx to redirect to /login (placeholder until auth is connected)
- Added employee layout with sidebar at app/employee/layout.tsx
- Added employee dashboard at /employee with summary cards (vacation balance, personal balance, pending requests), recent requests list, and history section

Shared components created:
- Sidebar: role-based navigation with icons and active page highlighting
- Header: greeting with date and "New Leave Request" button
- SummaryCard: reusable metric card with optional progress bar
- StatusBadge: color-coded status badges matching backend statuses
- LeaveTypeBadge: color-coded leave type badges

Also added leaveTypeId mapping in the leave request form to match the backend model (vacation = 1, personal = 2).

Using mock data for now. Will replace with API calls once backend integration begins.